### PR TITLE
Correct path of mcelog.conf for rhel fedora

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -65,4 +65,8 @@ default['mcelog']['page']['memory-ce-action'] = 'soft'
 
 # [trigger]
 default['mcelog']['trigger']['children-max'] = 2
-default['mcelog']['trigger']['directory'] = '/etc/mcelog'
+if platform_family?('rhel') && node['platform_version'].to_i >= 7
+  default['mcelog']['trigger']['directory'] = '/etc/mcelog/triggers'
+else
+  default['mcelog']['trigger']['directory'] = '/etc/mcelog'
+end

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -13,12 +13,3 @@ def mce_service_name
     'mcelog'
   end
 end
-
-# determine config dir based on platform
-def mce_config_dir
-  if platform_family?('rhel', 'fedora') # rubocop: disable Style/GuardClause
-    return '/etc/'
-  else
-    return '/etc/mcelog'
-  end
-end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,7 +33,7 @@ if mce_should_install?
     action :create
   end
 
-  template ::File.join(mce_config_dir, 'mcelog.conf') do
+  template ::File.join('/etc/mcelog', 'mcelog.conf') do
     source 'mcelog.conf.erb'
     owner 'root'
     group 'root'


### PR DESCRIPTION
On rhel/centos 6 and 7 the mcelog.conf is taken from /etc/mcelog and not /etc.
Here is an extract of the strace performed on the daemon start:
...
mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f26fe40b000
mmap(NULL, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f26fe409000
arch_prctl(ARCH_SET_FS, 0x7f26fe409740) = 0
mprotect(0x7f26fe1e7000, 16384, PROT_READ) = 0
mprotect(0x7f26fe631000, 8192, PROT_READ) = 0
mprotect(0x7f26fe413000, 4096, PROT_READ) = 0
munmap(0x7f26fe40c000, 21480)           = 0
brk(0)                                  = 0x7f26ff3de000
brk(0x7f26ff3ff000)                     = 0x7f26ff3ff000
brk(0)                                  = 0x7f26ff3ff000
open("/etc/mcelog/mcelog.conf", O_RDONLY) = 3
